### PR TITLE
removido o filtro da tela de dashboar e incluído na tela de transfer

### DIFF
--- a/lib/screens/dashboard.dart
+++ b/lib/screens/dashboard.dart
@@ -8,8 +8,6 @@ import 'package:pos_fiap_fin_mobile/utils/routes.dart';
 import '../components/screens/dashboard/balance/balance.dart';
 import '../components/screens/dashboard/extract/extract.dart';
 
-enum TransferFilterType { month, year, range, none }
-
 class DashboardScreen extends StatefulWidget {
   const DashboardScreen({super.key});
 
@@ -20,15 +18,6 @@ class DashboardScreen extends StatefulWidget {
 class _DashboardScreenState extends State<DashboardScreen> {
   final FirebaseAuth _auth = FirebaseAuth.instance;
 
-  // ---- AQUI SÃO OS ESTADOS PARA REALIZAR OS FILTROS
-  TransferFilterType _filterType = TransferFilterType.none;
-  int _selectedYear = DateTime.now().year;
-  int _selectedMonth = DateTime.now().month;
-  DateTimeRange? _selectedRange;
-
-  DateTime? _startDate;
-  DateTime? _endDate;
-
   @override
   void initState() {
     super.initState();
@@ -38,103 +27,6 @@ class _DashboardScreenState extends State<DashboardScreen> {
         return;
       }
     });
-    _applyFilter();
-  }
-
-  // ------ HELPERS DOS FILTROS
-  void _applyFilter() {
-    switch (_filterType) {
-      case TransferFilterType.month:
-        final first = DateTime(_selectedYear, _selectedMonth, 1);
-        final nextMonth = DateTime(_selectedYear, _selectedMonth + 1, 1);
-        setState(() {
-          _startDate = first;
-          _endDate = nextMonth;
-        });
-        break;
-
-      case TransferFilterType.year:
-        final first = DateTime(_selectedYear, 1, 1);
-        final nextYear = DateTime(_selectedYear + 1, 1, 1);
-        setState(() {
-          _startDate = first;
-          _endDate = nextYear;
-        });
-        break;
-
-      case TransferFilterType.range:
-        if (_selectedRange != null) {
-          final start = DateTime(
-              _selectedRange!.start.year, _selectedRange!.start.month, _selectedRange!.start.day);
-          final endExclusive = DateTime(
-              _selectedRange!.end.year, _selectedRange!.end.month, _selectedRange!.end.day)
-              .add(const Duration(days: 1));
-          setState(() {
-            _startDate = start;
-            _endDate = endExclusive;
-          });
-        }
-        break;
-
-      case TransferFilterType.none:
-        setState(() {
-          _startDate = null;
-          _endDate = null;
-        });
-        break;
-    }
-  }
-
-  List<DropdownMenuItem<int>> _monthItems() {
-    const months = [
-      'Janeiro','Fevereiro','Março','Abril','Maio','Junho',
-      'Julho','Agosto','Setembro','Outubro','Novembro','Dezembro'
-    ];
-    return List.generate(12, (i) {
-      final m = i + 1;
-      return DropdownMenuItem<int>(
-        value: m,
-        child: Text('${months[i]} ($m)'),
-      );
-    });
-  }
-
-  List<DropdownMenuItem<int>> _yearItems() {
-    final current = DateTime.now().year;
-    final years = List.generate(6, (i) => current - i);
-    return years.map((y) => DropdownMenuItem<int>(value: y, child: Text(y.toString()))).toList();
-  }
-
-  Future<void> _pickRange() async {
-    final now = DateTime.now();
-    final firstDay = DateTime(now.year - 5, 1, 1);
-    final lastDay  = DateTime(now.year + 1, 12, 31);
-
-    final picked = await showDateRangePicker(
-      context: context,
-      firstDate: firstDay,
-      lastDate: lastDay,
-      initialDateRange: _selectedRange ??
-          DateTimeRange(start: DateTime(now.year, now.month, 1), end: now),
-      saveText: 'Aplicar',
-      helpText: 'Selecione o período',
-    );
-
-    if (picked != null) {
-      setState(() {
-        _filterType = TransferFilterType.range;
-        _selectedRange = picked;
-      });
-      _applyFilter();
-    }
-  }
-
-  void _clearFilters() {
-    setState(() {
-      _filterType = TransferFilterType.none;
-      _selectedRange = null;
-    });
-    _applyFilter();
   }
 
   @override
@@ -173,134 +65,16 @@ class _DashboardScreenState extends State<DashboardScreen> {
           ],
         ),
       ),
-      body: SingleChildScrollView(
+      body: const SingleChildScrollView(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.start,
           children: [
-            const Balance(),
-            const NewTransferScreen(),
+            Balance(),
+            NewTransferScreen(),
 
-            // ---------------- FILTRO ----------------
-            Padding(
-              padding: const EdgeInsets.fromLTRB(12, 8, 12, 0),
-              child: Card(
-                child: Padding(
-                  padding: const EdgeInsets.all(12),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      const Text('Filtros do Extrato', style: TextStyle(fontWeight: FontWeight.bold)),
-                      const SizedBox(height: 8),
-
-                      Wrap(
-                        spacing: 12,
-                        runSpacing: 8,
-                        crossAxisAlignment: WrapCrossAlignment.center,
-                        children: [
-                          // TIPO DE FILTROS: Mês / Ano / Faixa / Nenhum
-                          DropdownButton<TransferFilterType>(
-                            value: _filterType,
-                            items: const [
-                              DropdownMenuItem(
-                                value: TransferFilterType.none,
-                                child: Text('Sem filtro'),
-                              ),
-                              DropdownMenuItem(
-                                value: TransferFilterType.month,
-                                child: Text('Por mês'),
-                              ),
-                              DropdownMenuItem(
-                                value: TransferFilterType.year,
-                                child: Text('Por ano'),
-                              ),
-                              DropdownMenuItem(
-                                value: TransferFilterType.range,
-                                child: Text('Por período'),
-                              ),
-                            ],
-                            onChanged: (val) {
-                              if (val == null) return;
-                              setState(() => _filterType = val);
-                              if (val != TransferFilterType.range) {
-                                _selectedRange = null;
-                              }
-                              _applyFilter();
-                            },
-                          ),
-
-                          // SE FOR POR MÊS MOSTRA A LISTA DE MÊS /ANO
-                          if (_filterType == TransferFilterType.month) ...[
-                            DropdownButton<int>(
-                              value: _selectedMonth,
-                              items: _monthItems(),
-                              onChanged: (m) {
-                                if (m == null) return;
-                                setState(() => _selectedMonth = m);
-                                _applyFilter();
-                              },
-                            ),
-                            DropdownButton<int>(
-                              value: _selectedYear,
-                              items: _yearItems(),
-                              onChanged: (y) {
-                                if (y == null) return;
-                                setState(() => _selectedYear = y);
-                                _applyFilter();
-                              },
-                            ),
-                          ],
-
-                          // SE FOR POR ANO MOSTRA APENAS ANO
-                          if (_filterType == TransferFilterType.year) ...[
-                            DropdownButton<int>(
-                              value: _selectedYear,
-                              items: _yearItems(),
-                              onChanged: (y) {
-                                if (y == null) return;
-                                setState(() => _selectedYear = y);
-                                _applyFilter();
-                              },
-                            ),
-                          ],
-
-                          // SE FOR POR RANGE MOSTRA BOTÕES PARA ESCOLHER
-                          if (_filterType == TransferFilterType.range) ...[
-                            ElevatedButton.icon(
-                              onPressed: _pickRange,
-                              icon: const Icon(Icons.calendar_month),
-                              label: Text(
-                                _selectedRange == null
-                                    ? 'Selecionar período'
-                                    : 'Período: ${_selectedRange!.start.day.toString().padLeft(2,'0')}/'
-                                      '${_selectedRange!.start.month.toString().padLeft(2,'0')}/'
-                                      '${_selectedRange!.start.year} '
-                                      '→ '
-                                      '${_selectedRange!.end.day.toString().padLeft(2,'0')}/'
-                                      '${_selectedRange!.end.month.toString().padLeft(2,'0')}/'
-                                      '${_selectedRange!.end.year}',
-                              ),
-                            ),
-                          ],
-
-                          // Limpar filtros
-                          TextButton.icon(
-                            onPressed: _clearFilters,
-                            icon: const Icon(Icons.clear),
-                            label: const Text('Limpar'),
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ),
-
-            // ---------------- EXTRACT COM FILTRO ----------------
+            // Extrato simples, sem filtros (usa padrão interno do componente)
             Extract(
               titleComponent: 'Extrato',
-              startDate: _startDate,
-              endDate: _endDate,
             ),
           ],
         ),

--- a/lib/screens/transfers.dart
+++ b/lib/screens/transfers.dart
@@ -5,6 +5,8 @@ import '../components/ui/header/header.dart' show Header;
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:pos_fiap_fin_mobile/utils/routes.dart';
 
+enum TransferFilterType { month, year, range, none }
+
 class TransfersScreen extends StatefulWidget {
   const TransfersScreen({super.key});
 
@@ -15,16 +17,121 @@ class TransfersScreen extends StatefulWidget {
 class _TransfersScreenState extends State<TransfersScreen> {
   final FirebaseAuth _auth = FirebaseAuth.instance;
 
+  // ---- ESTADOS DOS FILTROS
+  TransferFilterType _filterType = TransferFilterType.none;
+  int _selectedYear = DateTime.now().year;
+  int _selectedMonth = DateTime.now().month;
+  DateTimeRange? _selectedRange;
+
+  DateTime? _startDate;
+  DateTime? _endDate;
+
   @override
   void initState() {
     super.initState();
-
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (_auth.currentUser == null) {
         Navigator.pushReplacementNamed(context, Routes.login);
         return;
       }
     });
+    _applyFilter();
+  }
+
+  // ------ HELPERS DOS FILTROS
+  void _applyFilter() {
+    switch (_filterType) {
+      case TransferFilterType.month:
+        final first = DateTime(_selectedYear, _selectedMonth, 1);
+        final nextMonth = DateTime(_selectedYear, _selectedMonth + 1, 1);
+        setState(() {
+          _startDate = first;
+          _endDate = nextMonth;
+        });
+        break;
+
+      case TransferFilterType.year:
+        final first = DateTime(_selectedYear, 1, 1);
+        final nextYear = DateTime(_selectedYear + 1, 1, 1);
+        setState(() {
+          _startDate = first;
+          _endDate = nextYear;
+        });
+        break;
+
+      case TransferFilterType.range:
+        if (_selectedRange != null) {
+          final start = DateTime(
+              _selectedRange!.start.year, _selectedRange!.start.month, _selectedRange!.start.day);
+          final endExclusive = DateTime(
+                  _selectedRange!.end.year, _selectedRange!.end.month, _selectedRange!.end.day)
+              .add(const Duration(days: 1));
+          setState(() {
+            _startDate = start;
+            _endDate = endExclusive;
+          });
+        }
+        break;
+
+      case TransferFilterType.none:
+        setState(() {
+          _startDate = null;
+          _endDate = null;
+        });
+        break;
+    }
+  }
+
+  List<DropdownMenuItem<int>> _monthItems() {
+    const months = [
+      'Janeiro','Fevereiro','Março','Abril','Maio','Junho',
+      'Julho','Agosto','Setembro','Outubro','Novembro','Dezembro'
+    ];
+    return List.generate(12, (i) {
+      final m = i + 1;
+      return DropdownMenuItem<int>(
+        value: m,
+        child: Text('${months[i]} ($m)'),
+      );
+    });
+  }
+
+  List<DropdownMenuItem<int>> _yearItems() {
+    final current = DateTime.now().year;
+    final years = List.generate(6, (i) => current - i);
+    return years.map((y) => DropdownMenuItem<int>(value: y, child: Text(y.toString()))).toList();
+  }
+
+  Future<void> _pickRange() async {
+    final now = DateTime.now();
+    final firstDay = DateTime(now.year - 5, 1, 1);
+    final lastDay = DateTime(now.year + 1, 12, 31);
+
+    final picked = await showDateRangePicker(
+      context: context,
+      firstDate: firstDay,
+      lastDate: lastDay,
+      initialDateRange: _selectedRange ??
+          DateTimeRange(start: DateTime(now.year, now.month, 1), end: now),
+      saveText: 'Aplicar',
+      helpText: 'Selecione o período',
+    );
+
+    if (picked != null) {
+      setState(() {
+        _filterType = TransferFilterType.range;
+        _selectedRange = picked;
+      });
+      _applyFilter();
+    }
+  }
+
+  void _clearFilters() {
+    setState(() {
+      _filterType = TransferFilterType.none;
+      _selectedRange = null;
+    });
+    _applyFilter();
   }
 
   @override
@@ -38,7 +145,124 @@ class _TransfersScreenState extends State<TransfersScreen> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.start,
           children: [
-            Extract(uploadImage: true, titleComponent: 'Transferências'),
+            // ---------------- FILTRO ----------------
+            Padding(
+              padding: const EdgeInsets.fromLTRB(12, 8, 12, 0),
+              child: Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text('Filtros do Extrato',
+                          style: TextStyle(fontWeight: FontWeight.bold)),
+                      const SizedBox(height: 8),
+                      Wrap(
+                        spacing: 12,
+                        runSpacing: 8,
+                        crossAxisAlignment: WrapCrossAlignment.center,
+                        children: [
+                          DropdownButton<TransferFilterType>(
+                            value: _filterType,
+                            items: const [
+                              DropdownMenuItem(
+                                value: TransferFilterType.none,
+                                child: Text('Sem filtro'),
+                              ),
+                              DropdownMenuItem(
+                                value: TransferFilterType.month,
+                                child: Text('Por mês'),
+                              ),
+                              DropdownMenuItem(
+                                value: TransferFilterType.year,
+                                child: Text('Por ano'),
+                              ),
+                              DropdownMenuItem(
+                                value: TransferFilterType.range,
+                                child: Text('Por período'),
+                              ),
+                            ],
+                            onChanged: (val) {
+                              if (val == null) return;
+                              setState(() => _filterType = val);
+                              if (val != TransferFilterType.range) {
+                                _selectedRange = null;
+                              }
+                              _applyFilter();
+                            },
+                          ),
+
+                          if (_filterType == TransferFilterType.month) ...[
+                            DropdownButton<int>(
+                              value: _selectedMonth,
+                              items: _monthItems(),
+                              onChanged: (m) {
+                                if (m == null) return;
+                                setState(() => _selectedMonth = m);
+                                _applyFilter();
+                              },
+                            ),
+                            DropdownButton<int>(
+                              value: _selectedYear,
+                              items: _yearItems(),
+                              onChanged: (y) {
+                                if (y == null) return;
+                                setState(() => _selectedYear = y);
+                                _applyFilter();
+                              },
+                            ),
+                          ],
+
+                          if (_filterType == TransferFilterType.year) ...[
+                            DropdownButton<int>(
+                              value: _selectedYear,
+                              items: _yearItems(),
+                              onChanged: (y) {
+                                if (y == null) return;
+                                setState(() => _selectedYear = y);
+                                _applyFilter();
+                              },
+                            ),
+                          ],
+
+                          if (_filterType == TransferFilterType.range) ...[
+                            ElevatedButton.icon(
+                              onPressed: _pickRange,
+                              icon: const Icon(Icons.calendar_month),
+                              label: Text(
+                                _selectedRange == null
+                                    ? 'Selecionar período'
+                                    : 'Período: '
+                                      '${_selectedRange!.start.day.toString().padLeft(2, '0')}/'
+                                      '${_selectedRange!.start.month.toString().padLeft(2, '0')}/'
+                                      '${_selectedRange!.start.year} → '
+                                      '${_selectedRange!.end.day.toString().padLeft(2, '0')}/'
+                                      '${_selectedRange!.end.month.toString().padLeft(2, '0')}/'
+                                      '${_selectedRange!.end.year}',
+                              ),
+                            ),
+                          ],
+
+                          TextButton.icon(
+                            onPressed: _clearFilters,
+                            icon: const Icon(Icons.clear),
+                            label: const Text('Limpar'),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+
+            // ---------------- EXTRACT COM FILTRO ----------------
+            Extract(
+              uploadImage: true,
+              titleComponent: 'Transferências',
+              startDate: _startDate,
+              endDate: _endDate,
+            ),
           ],
         ),
       ),
@@ -47,22 +271,22 @@ class _TransfersScreenState extends State<TransfersScreen> {
           padding: EdgeInsets.zero,
           children: [
             DrawerHeader(
-              decoration: BoxDecoration(color: Color(0xFF004D61)),
+              decoration: const BoxDecoration(color: Color(0xFF004D61)),
               child: Text(
                 _auth.currentUser?.displayName ?? 'Usuário',
-                style: TextStyle(color: Colors.white, fontSize: 24),
+                style: const TextStyle(color: Colors.white, fontSize: 24),
               ),
             ),
             ListTile(
-              leading: Icon(Icons.home),
-              title: Text('Início'),
+              leading: const Icon(Icons.home),
+              title: const Text('Início'),
               onTap: () {
                 Navigator.pushNamed(context, Routes.dashboard);
               },
             ),
             ListTile(
-              leading: Icon(Icons.logout),
-              title: Text('Sair'),
+              leading: const Icon(Icons.logout),
+              title: const Text('Sair'),
               onTap: () async {
                 FirebaseLogoutUtil.logout(context);
               },

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.61"
+  args:
+    dependency: transitive
+    description:
+      name: args
+      sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
   async:
     dependency: transitive
     description:
@@ -250,10 +258,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: "5398f14efa795ffb7a33e9b6a08798b26a180edac4ad7db3f231e40f82ce11e1"
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "6.0.0"
   flutter_multi_formatter:
     dependency: "direct main"
     description:
@@ -318,6 +326,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  flutter_svg:
+    dependency: "direct main"
+    description:
+      name: flutter_svg
+      sha256: b9c2ad5872518a27507ab432d1fb97e8813b05f0fc693f9d40fad06d073e0678
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -452,10 +468,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: c35bb79562d980e9a453fc715854e1ed39e24e7d0297a880ef54e17f9874a9d7
+      sha256: a5e2b223cb7c9c8efdc663ef484fdd95bb243bff242ef5b13e26883547fce9a0
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.1"
+    version: "6.0.0"
   matcher:
     dependency: transitive
     description:
@@ -496,6 +512,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_parsing:
+    dependency: transitive
+    description:
+      name: path_parsing
+      sha256: "883402936929eac138ee0a45da5b0f2c80f89913e6dc3bf77eb65b84b409c6ca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   path_provider:
     dependency: transitive
     description:
@@ -544,6 +568,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "1a97266a94f7350d30ae522c0af07890c70b8e62c71e8e3920d1db4d23c057d1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   platform:
     dependency: transitive
     description:
@@ -621,6 +653,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  vector_graphics:
+    dependency: transitive
+    description:
+      name: vector_graphics
+      sha256: a4f059dc26fc8295b5921376600a194c4ec7d55e72f2fe4c7d2831e103d461e6
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.19"
+  vector_graphics_codec:
+    dependency: transitive
+    description:
+      name: vector_graphics_codec
+      sha256: "99fd9fbd34d9f9a32efd7b6a6aae14125d8237b10403b422a6a6dfeac2806146"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.13"
+  vector_graphics_compiler:
+    dependency: transitive
+    description:
+      name: vector_graphics_compiler
+      sha256: d354a7ec6931e6047785f4db12a1f61ec3d43b207fc0790f863818543f8ff0dc
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.19"
   vector_math:
     dependency: transitive
     description:
@@ -661,6 +717,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.1"
 sdks:
   dart: ">=3.8.1 <4.0.0"
   flutter: ">=3.29.0"


### PR DESCRIPTION
## ✨ Summary
Esta PR move a lógica de **Filtros do Extrato** do componente `DashboardScreen` (`dashboard.dart`) para o componente `TransfersScreen` (`transfers.dart`).

## 🛠 Changes
- Removida a implementação de filtros (mês, ano, período, sem filtro) do `DashboardScreen`.
- Criada a lógica de filtros no `TransfersScreen`, incluindo:
  - Seleção por **mês/ano**.
  - Seleção por **ano**.
  - Seleção por **período customizado** (date range).
  - Opção de **limpar filtros**.
- `Extract` no **Dashboard** agora é renderizado sem filtros.
- `Extract` em **Transfers** recebe os filtros aplicados (`startDate` e `endDate`).

## 📸 Affected Areas
- **Dashboard**: exibe o extrato sem opções de filtro.
- **Transfers**: agora contém os filtros completos antes do componente `Extract`.

## ✅ Motivation
A separação foi feita para que os filtros fiquem centralizados apenas na tela de **Transferências**, tornando o `Dashboard` mais limpo e mantendo o comportamento esperado do extrato em cada contexto.
